### PR TITLE
MySQL insert error message

### DIFF
--- a/src/handlers/CDatabaseHandler_mysql.cpp
+++ b/src/handlers/CDatabaseHandler_mysql.cpp
@@ -126,8 +126,10 @@ CDatabaseResource *CDatabaseTransaction::insert(const std::string &s, const std:
 		}
 	}
 	else
+	{
 		fprintf(stderr, "QUERY ERROR: %s\n", s.c_str());
-	return new CDatabaseResource(0);
+		return new CDatabaseResource(s);
+	}
 }
 
 


### PR DESCRIPTION
Added error message to MySQL's CDatabaseResource when INSERT command fails to execute. The error message helps in identifying errors when calling insert on client code by using the `handle->isError()` method. Otherwise, calling `handle->isError()` would return false even though the INSERT command failed.