### PR TITLE
Exposed exec method on ITransaction

### DIFF
--- a/src/handlers/CDatabaseHandler_mysql.cpp
+++ b/src/handlers/CDatabaseHandler_mysql.cpp
@@ -126,8 +126,10 @@ CDatabaseResource *CDatabaseTransaction::insert(const std::string &s, const std:
 		}
 	}
 	else
+	{
 		fprintf(stderr, "QUERY ERROR: %s\n", s.c_str());
-	return new CDatabaseResource(0);
+		return new CDatabaseResource(s);
+	}
 }
 
 

--- a/src/include/solusek/ITransaction.h
+++ b/src/include/solusek/ITransaction.h
@@ -19,6 +19,8 @@ namespace solusek
 	class ITransaction
 	{
 	public:
+		virtual int exec(const std::string &s) = 0;
+		
 		virtual MDatabaseHandle *insert(const char *tableName, std::map<std::string, std::string> vars) = 0;
 
 		virtual MDatabaseHandle *selectOne(const char *tableName, std::vector<std::string> find, std::map<std::string, std::string> vars, const std::string &sort = std::string()) = 0;

--- a/src/server/CTransaction.cpp
+++ b/src/server/CTransaction.cpp
@@ -20,6 +20,17 @@ namespace solusek
 		delete T;
 	}
 
+	int CTransaction::exec(const std::string &s)
+	{
+		CDatabaseHandler *h = (CDatabaseHandler*)H;
+		while(Lock)
+			usleep(1);
+		Lock = true;
+		int r = T->exec(s);
+		Lock = false;
+		return r;
+	}
+
 	MDatabaseHandle *CTransaction::insert(const char *tableName, std::map<std::string, std::string> vars)
 	{
 		CDatabaseHandler *h = (CDatabaseHandler*)H;

--- a/src/server/CTransaction.h
+++ b/src/server/CTransaction.h
@@ -33,6 +33,8 @@ namespace solusek
 
 		virtual void cleanup();
 
+		virtual int exec(const std::string &s);
+
 		virtual MDatabaseHandle *insert(const char *tableName, std::map<std::string, std::string> vars);
 
 		virtual bool update(const char *tableName, std::map<std::string, std::string> find, std::map<std::string, std::string> vars);


### PR DESCRIPTION
Exposed CDatabaseHandler::exec method through the ITransaction interface to enable client code execute SQL commands apart from SELECTs and INSERTs.