### PR TITLE
Query returns true even if result set is empty.

### DIFF
--- a/src/handlers/CDatabaseHandler_mysql.cpp
+++ b/src/handlers/CDatabaseHandler_mysql.cpp
@@ -159,8 +159,8 @@ bool CDatabaseTransaction::query(const std::string &s, void(*callback)(const DBR
 					callback(result, param);
 			}
 			mysql_free_result(res);
-			return true;			
 		}
+		return true;
  	}
 	else
 		fprintf(stderr, "QUERY ERROR: %s\n", s.c_str());


### PR DESCRIPTION
Calls to `ITransaction::update()` were returning false due to the result of the query being empty. Returned value was moved outside the result set check condition to ensure that a successful query always return true.