### PR TITLE
Added a Headers property to MResponse

### DIFF
--- a/src/client/CClient.cpp
+++ b/src/client/CClient.cpp
@@ -111,6 +111,7 @@ namespace solusek
 	MResponse CClient::runRequest(const std::string& body, bool ignoreResult)
 	{
 		std::string contentType("application/json"), location;
+		std::map<std::string, std::string> headers;
 		int port = 80;
 
 		std::size_t n1 = Endpoint.find("://");
@@ -291,8 +292,6 @@ namespace solusek
 
 			if(!ignoreResult)
 			{
-
-				std::map<std::string, std::string> headers;
 				char retBuf[2];
 				int ex = 0;
 				std::string line;
@@ -450,6 +449,7 @@ namespace solusek
 		MResponse ret(code, resp);
 		ret.ContentType = contentType;
 		ret.Location = location;
+		ret.Headers = headers;
 		return ret;
 	}
 }

--- a/src/handlers/CDatabaseHandler_mysql.cpp
+++ b/src/handlers/CDatabaseHandler_mysql.cpp
@@ -159,8 +159,8 @@ bool CDatabaseTransaction::query(const std::string &s, void(*callback)(const DBR
 					callback(result, param);
 			}
 			mysql_free_result(res);
-			return true;			
 		}
+		return true;
  	}
 	else
 		fprintf(stderr, "QUERY ERROR: %s\n", s.c_str());

--- a/src/include/solusek/MResponse.h
+++ b/src/include/solusek/MResponse.h
@@ -7,6 +7,7 @@
 #ifndef __M_RESPONSE_INCLUDED__
 #define __M_RESPONSE_INCLUDED__
 #include "MCookie.h"
+#include <map>
 #include <string>
 #include <vector>
 
@@ -20,7 +21,8 @@ namespace solusek
 
 		int Code;
 		std::string Body, ContentType, Date, SID, Location;
-    std::vector<MCookie> Cookies;
+    	std::vector<MCookie> Cookies;
+		std::map<std::string, std::string> Headers;
 
 		std::string getCodeDescription() const
 		{


### PR DESCRIPTION
Let MResponse carry the whole list of headers returned by the request besides Content-Type and Location.